### PR TITLE
rollback from initrd

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@
 #
 AUTOMAKE_OPTIONS = 1.6 foreign check-news dist-bzip2
 #
-SUBDIRS = sbin man systemd plugins dracut
+SUBDIRS = sbin man systemd plugins dracut grub
 
 CLEANFILES = *~
 

--- a/configure.ac
+++ b/configure.ac
@@ -39,4 +39,5 @@ JH_CHECK_XML_CATALOG([http://docbook.sourceforge.net/release/xsl/current/manpage
 AM_CONDITIONAL(ENABLE_REGENERATE_MAN, test x$enable_man != xno)
 
 AC_OUTPUT([Makefile sbin/Makefile man/Makefile systemd/Makefile \
-	plugins/Makefile dracut/Makefile sbin/health-checker])
+	plugins/Makefile dracut/Makefile grub/Makefile \
+	sbin/health-checker])

--- a/dracut/health-checker-emergency.sh
+++ b/dracut/health-checker-emergency.sh
@@ -81,7 +81,9 @@ info "health checker emergency mode"
 # Make sure we know root device
 [ -z "$root" ] && root=$(getarg root=)
 
-if [ -n "$root" -a -z "${root%%block:*}" ]; then
+if getargbool 1 rd.shell -d -y rdshell || getarg rd.break -d rdbreak; then
+  info "health checker: manual invocation of emergency shell, doing nothing"
+elif [ -n "$root" -a -z "${root%%block:*}" ]; then
 
   info "root device: ${root}"
 

--- a/dracut/health-checker-emergency.sh
+++ b/dracut/health-checker-emergency.sh
@@ -19,7 +19,8 @@ set_btrfs_id()
 rollback()
 {
     . ${STATE_FILE}
-    btrfs subvolume set-default ${LAST_WORKING_BTRFS_ID} ${NEWROOT}/.snapshots
+    mount -o remount,rw ${NEWROOT}
+    btrfs subvolume set-default ${LAST_WORKING_BTRFS_ID} ${NEWROOT}
     if [ $? -ne 0 ]; then
         warn "ERROR: btrfs set-default $BTRFS_ID failed!"
         return 1
@@ -43,13 +44,13 @@ error_decission()
       rollback
       if [ $? -eq 0 ]; then
         umount /run/health-checker
-        emergency_shell --shutdown reboot
+        reboot
       fi
   elif [ ! -f ${REBOOTED_STATE} ]; then
       warn "Machine didn't come up correct, try a reboot"
       echo `date "+%Y-%m-%d %H:%M"` > ${REBOOTED_STATE}
       umount /run/health-checker
-      emergency_shell --shutdown reboot
+      reboot
   else
       warn "Machine didn't come up correct, start emergency shell"
       return 0

--- a/dracut/module-setup.sh
+++ b/dracut/module-setup.sh
@@ -14,6 +14,6 @@ depends() {
 install() {
     inst_hook emergency 90 "$moddir"/health-checker-emergency.sh
 
-    inst_multiple date btrfs awk
+    inst_multiple date btrfs awk grub2-editenv
 }
 

--- a/grub/05_health_check
+++ b/grub/05_health_check
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -e
+
+cat << EOF
+# Only consider showing a fallback entry on the top level menu
+if [ -z "\${chosen}" -a -z "\${boot_once}" ]; then
+  # If flag is set on boot the last start seems to have failed - the flag
+  # should have been cleared by userspace
+  if [ "\${health_checker_flag}" -ge 1 ]; then
+    # Reset flag; it will be set again by a supported menu entry.
+    # This prevents getting stuck in a loop when booting an entry that
+    # doesn't support this flag yet.
+    health_checker_flag=0
+    save_env -f "\${env_block}" health_checker_flag
+    # Try to mount /var/lib/misc from know subvolume locations
+    btrfs-mount-subvol (\${root}) /var /@/var
+    btrfs-mount-subvol (\${root}) /var/lib/misc /@/var/lib/misc
+
+    # Due to boo#1048088 btrfs-list-subvols currently doesn't give a list of
+    # subvolumes, so it's not possible to map
+    # /var/lib/misc/health-checker.state to a snapshot directory; use
+    # transactional-update state file as a workaround.
+    if [ -e /var/lib/misc/transactional-update.state ]; then
+      source /var/lib/misc/transactional-update.state
+      btrfs-mount-subvol (\$root) /.snapshots @/.snapshots
+      for snapshot in \${LAST_WORKING_SNAPSHOTS}; do
+        if [ -e "/.snapshots/\${snapshot}/grub-snapshot.cfg" ]; then
+          menuentry "Previous boot failed; booting snapshot \${snapshot}" { true; }
+          source /.snapshots/\${snapshot}/grub-snapshot.cfg
+          menuentry "________________" { true; }
+          set default=1
+          break
+        fi;
+      done
+    fi
+  fi
+fi
+EOF

--- a/grub/83_health_check_marker
+++ b/grub/83_health_check_marker
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -e
+
+# GRUB's grub2_mkconfig script currently has some serious limitations, one of 
+# them beeing not providing a way to modify anything done by previous scripts;
+# unfortunately health_checker requires additional commands to be executed
+# when selecting a boot entry (which is usually created by 10_linux), so as a
+# horrible workaround the temporary output will be modified by a sed script.
+#
+# Will only work if output is redirected to a file (which should be the case
+# in all automated cases), but not when the user is calling grub2-mkconfig by
+# hand without redirection.
+
+cfgfile="`readlink /proc/$$/fd/1`"
+if [ -f "$cfgfile" ]; then
+  lines_to_add='\n\thealth_checker_flag=1\n\tsave_env -f "${env_block}" health_checker_flag'
+
+  # The sed expression below will inject contents into the opened file; the
+  # original process will not notice that and will continue writing from the
+  # last position. To set the pointer to the correct posision add the number
+  # of characters which will be injected to the file (they won't appear in
+  # the final output).
+  echo -n -e $lines_to_add
+
+  sed 's/^\(menuentry .*\)/\1\n\thealth_checker_flag=1\n\tsave_env -f "${env_block}" health_checker_flag/' "$cfgfile" > "$cfgfile".health_checker
+  cp "$cfgfile".health_checker "$cfgfile"
+  rm "$cfgfile".health_checker
+fi
+
+cat << EOF
+# Prevent infinite waiting for disk if drivers in initrd are broken
+extra_cmdline="\${extra_cmdline} rd.timeout=60"
+EOF
+

--- a/grub/Makefile.am
+++ b/grub/Makefile.am
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2018 Ignaz Forster <iforster@suse.com>
+#
+
+modulesdir = @sysconfdir@/grub.d
+
+modules_SCRIPTS = 05_health_check 83_health_check_marker
+
+EXTRA_DIST = $(SCRIPTS)

--- a/sbin/health-checker.in
+++ b/sbin/health-checker.in
@@ -75,6 +75,10 @@ error_decission()
   fi
 }
 
+# Clear GRUB flag (used to determine if system was able to boot at all)
+echo "Clearing GRUB flag"
+grub2-editenv - set health_checker_flag=0
+
 echo "Starting health check"
 FAILED=0;
 for script in ${PLUGINDIR}/* ; do


### PR DESCRIPTION
This repository will enable several mechanisms to recover from a broken initrd:
* The existing, but deactivated dracut emergency shell hook was slightly modified to actually work. However this will only help if the root file system is still writable.
* To recover from an initrd with broken or missing disk (or file system) drivers GRUB is extended to store a flag into the GRUB environment block (see the comments of the commit for more information).

**Dependencies:**
* a modified grub2 version is required to store the flag into the Btrfs header (this as been discussed with the grub2 maintainers)
* a new version of transactional-update is required to be compatible with the new grub2 version (containing https://github.com/thkukuk/transactional-update/pull/8/commits/2b90dd916ed2d17b7766957d8eb1d5a4cee64d52).

**Testing:**
On a Kubic system
* first update transactional-update (e.g. from https://software.opensuse.org//download.html?project=home%3Afos%3Abranches%3ABase%3ASystem&package=transactional-update)
* then update grub2 (e.g. from https://software.opensuse.org//download.html?project=home%3Afos%3Abranches%3ABase%3ASystem&package=grub2)
* then install health-checker (test repository available on https://software.opensuse.org//download.html?project=home%3Afos%3Abranches%3Adevel%3ACaaSP&package=health-checker)

**Packaging:**
See https://build.opensuse.org/package/view_file/home:fos:branches:devel:CaaSP/health-checker/health-checker.spec?expand=1 for a packaging example.

Please actually review these changes before merging, they may contain a few surprises :)
If this pull request will be approved I'll submit a maintenance request for the grub2 package.