### PR TITLE
Fix crio package name

### DIFF
--- a/plugins/crio.sh
+++ b/plugins/crio.sh
@@ -2,7 +2,7 @@
 
 run_checks() {
     # Check first if it is installed:
-    rpm -q --quiet crio
+    rpm -q --quiet cri-o
     test $? -ne 0 && return
 
     # ignore if crio is not enabled.


### PR DESCRIPTION
Service: crio
Package: cri-o

```bash
linux-61k5:~ # rpm -q crio
package crio is not installed

linux-61k5:~ # rpm -q cri-o
cri-o-1.14.0-3.1.x86_64

linux-61k5:~ # cat /etc/YaST2/build 
openSUSE - openSUSE-MicroOS-DVD-x86_64-Build1154.2-Media
```