### PR TITLE
Ask PKG_CONFIG for application paths

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,9 @@ issue-generator NEWS -- history of user-visible changes.
 
 Copyright (C) 2017-2020 Thorsten Kukuk et al.
 
+Version 1.3.2
+* Use pkgconf to determine installation directories
+
 Version 1.3.1
 * Support multiple menuentries in GRUB configuration
   [gh#kubic-project/health-checker#5]

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT(health-checker, 1.3.1)
+AC_INIT(health-checker, 1.3.2)
 AM_INIT_AUTOMAKE
 AC_CONFIG_SRCDIR([sbin/health-checker.in])
 AC_PREFIX_DEFAULT(/usr)

--- a/configure.ac
+++ b/configure.ac
@@ -7,17 +7,10 @@ AC_PREFIX_DEFAULT(/usr)
 AC_SUBST(PACKAGE)
 AC_SUBST(VERSION)
 
-test "${prefix}" = "NONE" && prefix="/usr"
-test "${exec_prefix}" = "NONE" && exec_prefix="/usr"
-test ${libexecdir} = '${exec_prefix}/libexec' && libexecdir="${exec_prefix}/lib"
-TMPFILESDIR=${libexecdir}/tmpfiles.d
-SYSTEMDDIR=${libexecdir}/systemd/system
-PLUGINDIR=${libexecdir}/health-checker
-DRACUTDIR=${libexecdir}/dracut
-AC_SUBST(TMPFILESDIR)
-AC_SUBST(SYSTEMDDIR)
-AC_SUBST(PLUGINDIR)
-AC_SUBST(DRACUTDIR)
+PKG_CHECK_VAR([systemdsystemunitdir], [systemd], [systemdsystemunitdir], [],
+	[AC_MSG_ERROR([Could not determine value for 'systemdsystemunitdir' - is the 'systemd.pc' file installed?])])
+PKG_CHECK_VAR([dracutmodulesdir], [dracut], [dracutmodulesdir], [],
+	[AC_MSG_ERROR([Could not determine value for 'dracutmodulesdir' - is the 'dracut.pc' file installed?])])
 
 AC_PROG_INSTALL
 AC_PROG_LN_S

--- a/dracut/Makefile.am
+++ b/dracut/Makefile.am
@@ -2,7 +2,7 @@
 # Copyright (c) 2017 Thorsten Kukuk <kukuk@suse.de>
 #
 
-modulesdir = @DRACUTDIR@/modules.d/50health-checker
+modulesdir = $(dracutmodulesdir)/50health-checker
 
 modules_SCRIPTS = health-checker-emergency.sh module-setup.sh
 

--- a/grub/Makefile.am
+++ b/grub/Makefile.am
@@ -2,7 +2,7 @@
 # Copyright (c) 2018 Ignaz Forster <iforster@suse.com>
 #
 
-modulesdir = @sysconfdir@/grub.d
+modulesdir = $(sysconfdir)/grub.d
 
 modules_SCRIPTS = 05_health_check 83_health_check_marker
 

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -2,7 +2,7 @@
 # Copyright (c) 2017 Thorsten Kukuk <kukuk@suse.de>
 #
 
-plugindir = @PLUGINDIR@
+plugindir = ${libexecdir}/health-checker
 
 plugin_SCRIPTS = health-check-tester.sh etcd.sh etc-overlayfs.sh \
 	rebootmgr.sh btrfs-subvolumes-mounted.sh crio.sh kubelet.sh

--- a/systemd/Makefile.am
+++ b/systemd/Makefile.am
@@ -2,7 +2,7 @@
 # Copyright (c) 2016 Thorsten Kukuk <kukuk@suse.de>
 #
 
-systemddir = @SYSTEMDDIR@
+systemddir = $(systemdsystemunitdir)
 
 systemd_DATA = health-checker.service 
 


### PR DESCRIPTION
Don't guess the paths where the applications may store their files - just ask pkg-config. This should fix the breakage due to the libexec path change.