### PR TITLE
Improve system reliability

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,12 @@ issue-generator NEWS -- history of user-visible changes.
 
 Copyright (C) 2017-2020 Thorsten Kukuk et al.
 
+Version 1.4
+* Add checks for /tmp and systemd-logind
+* Transition system into emergency mode on repeated failures to prevent
+  random jobs from modifying the broken system
+* Build system cleanup
+
 Version 1.3.4
 * Really fix plugindir replacement in configure.ac script
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 dnl Process this file with autoconf to produce a configure script.
-AC_INIT(health-checker, 1.3.4)
+AC_INIT(health-checker, 1.4)
 AM_INIT_AUTOMAKE
 AC_PREFIX_DEFAULT(/usr)
 

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -5,6 +5,7 @@
 plugindir = ${libexecdir}/health-checker
 
 plugin_SCRIPTS = health-check-tester.sh etcd.sh etc-overlayfs.sh \
-	rebootmgr.sh btrfs-subvolumes-mounted.sh crio.sh kubelet.sh
+	rebootmgr.sh btrfs-subvolumes-mounted.sh crio.sh kubelet.sh \
+	tmp.sh logind.sh
 
 EXTRA_DIST = template.sh ${SCRIPTS}

--- a/plugins/logind.sh
+++ b/plugins/logind.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+run_checks() {
+    systemctl is-enabled -q systemd-logind
+    test $? -ne 0 && return
+
+    systemctl is-failed -q systemd-logind
+    test $? -ne 1 && exit 1
+}
+
+stop_services() {
+    systemctl stop systemd-logind
+}
+
+case "$1" in
+    check)
+	run_checks
+	;;
+    stop)
+	stop_services
+	;;
+    *)
+	echo "Usage: $0 {check|stop}"
+	exit 1
+	;;
+esac
+
+exit 0

--- a/plugins/tmp.sh
+++ b/plugins/tmp.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Check if tmp is mounted and writable
+run_checks() {
+    systemctl is-failed -q tmp.mount
+    test $? -ne 1 && exit 1
+
+    TMPF=$(mktemp -q /tmp/test-for-read-write.XXXXXX) || exit 1
+    rm ${TMPF}
+}
+
+case "$1" in
+    check)
+	run_checks
+	;;
+    stop)
+	;;
+    *)
+	echo "Usage: $0 {check|stop}"
+	exit 1
+	;;
+esac
+
+exit 0

--- a/sbin/health-checker.in
+++ b/sbin/health-checker.in
@@ -126,8 +126,9 @@ error_decission()
       telem_send_record 1
       systemctl reboot
   else
-      create_log user.emerg "Machine didn't come up correct, stop services"
+      create_log user.emerg "Machine didn't come up correct, starting emergency shell"
       stop_services
+      systemctl start emergency.target
   fi
 }
 

--- a/systemd/health-checker.service
+++ b/systemd/health-checker.service
@@ -5,6 +5,7 @@ After=crio.service
 After=etcd.service
 After=kubelet.service
 After=rebootmgr.service
+After=systemd-logind.service
 Wants=local-fs.target
 
 [Service]


### PR DESCRIPTION
* Add more checks, triggered by a broken _/tmp_ mount
* Prevent the system from executing more stuff when it is known to be broken by switching into emergency.target