### PR TITLE
Moving /usr/libexec/health-checker to /usr/local/libexec/health-checker.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ AC_PREFIX_DEFAULT(/usr)
 
 AC_SUBST(PACKAGE)
 AC_SUBST(VERSION)
+AC_SUBST(libexecdir, "[/usr/local/libexec]")
 
 PKG_CHECK_VAR([systemdsystemunitdir], [systemd], [systemdsystemunitdir], [],
 	[AC_MSG_ERROR([Could not determine value for 'systemdsystemunitdir' - is the 'systemd.pc' file installed?])])


### PR DESCRIPTION
So the user can create his own checking scripts.
I have tested the call health-checker which is using /usr/local/libexec/health-checker too.
Sure, the spec file has also to be adapted after the merge.