### PR TITLE
fix(grub): adapt rd.retry to also trigger initqueue timeout tasks

### DIFF
--- a/grub/83_health_check_marker
+++ b/grub/83_health_check_marker
@@ -32,6 +32,6 @@ fi
 
 cat << EOF
 # Prevent infinite waiting for disk if drivers in initrd are broken
-extra_cmdline="\${extra_cmdline} rd.timeout=60"
+extra_cmdline="\${extra_cmdline} rd.timeout=60 rd.retry=45"
 EOF
 


### PR DESCRIPTION
### Bugfix description

The default value of [rd.retry](https://github.com/dracutdevs/dracut/blob/master/modules.d/98dracut-systemd/dracut-initqueue.sh#L15) is 180 seconds, although it is stated _wrong_ or better to say [outdated](https://github.com/dracutdevs/dracut/commit/517d27a75f678d4c295cbb07687453950b55df5a) in the [man page](https://github.com/dracutdevs/dracut/blob/master/man/dracut.cmdline.7.asc#misc). As long as the [rd.timeout](https://github.com/kubic-project/health-checker/blob/master/grub/83_health_check_marker#L35) is way below this value, the [initqueue timeout hook](https://github.com/dracutdevs/dracut/blob/master/man/dracut.modules.7.asc#initqueue) of dracut will never be triggered. It is calculated by the fomular:
_[initqueue timeout](https://github.com/dracutdevs/dracut/blob/master/modules.d/98dracut-systemd/dracut-initqueue.sh#L59) = (2 * rd.retry) / 3_

_Note_: Don't get fooled by the times two [multiplication](https://github.com/dracutdevs/dracut/blob/master/modules.d/98dracut-systemd/dracut-initqueue.sh#L16) of RDRETRY, the loop is triggered every [0.5 seconds](https://github.com/dracutdevs/dracut/blob/master/modules.d/98dracut-systemd/dracut-initqueue.sh#L53) ;)

In the following scenario, a system boot will fail due to lowering rd.timeout to 60 seconds.

### Error scenario

System with two raid1 (md0+md1) partitions. One disk fails and system tries to boot:

- udev discovers raid partitions and starts to assemble them [incrementally](https://github.com/dracutdevs/dracut/blob/master/modules.d/90mdraid/65-md-incremental-imsm.rules#L42)
- both raid partitions stay degraded because second disk is missing
- rd.retry will never expire to trigger the initqueue hook and so it won't [execute](https://github.com/dracutdevs/dracut/blob/master/modules.d/90mdraid/65-md-incremental-imsm.rules#L34) [/sbin/mdraid_start](https://github.com/dracutdevs/dracut/blob/master/modules.d/90mdraid/mdraid_start.sh#L21) to fix the problem
- dracut timeouts and falls into emergency shell
- manually starting the degraded raid or executing the mdraid_start script is necessary

**NB**: There is currently a bug in dracut, which prevents starting a system with two or more degraded raid partitions. [PR](https://github.com/dracutdevs/dracut/pull/1633) already submitted.