### PR TITLE
mount check fails for some subvolumes contains a dot (.)

### DIFF
--- a/plugins/btrfs-subvolumes-mounted.sh
+++ b/plugins/btrfs-subvolumes-mounted.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 run_checks() {
-
-    MOUNTS=`grep "btrfs.*subvol=" /etc/fstab | awk '{print $2}' | sed -e 's|^/||g' -e 's|-|\\\x2d|g' -e 's|^\.|\\\x2e|g' -e 's|/|-|g'`
+    MOUNTS=`grep "btrfs.*subvol=" /etc/fstab | awk '{print $2}'`
     for i in ${MOUNTS}; do
-        systemctl is-failed -q $i.mount
+        path=$(systemd-escape -p "${i}")
+        systemctl is-failed -q "${path}.mount"
         test $? -ne 1 && exit 1
     done
 }

--- a/plugins/btrfs-subvolumes-mounted.sh
+++ b/plugins/btrfs-subvolumes-mounted.sh
@@ -2,7 +2,7 @@
 
 run_checks() {
 
-    MOUNTS=`grep "btrfs.*subvol=" /etc/fstab | awk '{print $2}' | sed -e 's|^/||g' -e 's|-|\\\x2d|g' -e 's|\.|\\\x2e|g' -e 's|/|-|g'`
+    MOUNTS=`grep "btrfs.*subvol=" /etc/fstab | awk '{print $2}' | sed -e 's|^/||g' -e 's|-|\\\x2d|g' -e 's|^\.|\\\x2e|g' -e 's|/|-|g'`
     for i in ${MOUNTS}; do
         systemctl is-failed -q $i.mount
         test $? -ne 1 && exit 1

--- a/plugins/btrfs-subvolumes-mounted.sh
+++ b/plugins/btrfs-subvolumes-mounted.sh
@@ -3,7 +3,7 @@
 run_checks() {
     MOUNTS=`grep "btrfs.*subvol=" /etc/fstab | awk '{print $2}'`
     for i in ${MOUNTS}; do
-        path=$(systemd-escape -p "${i}")
+        path=$(systemd-escape -p "$(echo -e ${i})")
         systemctl is-failed -q "${path}.mount"
         test $? -ne 1 && exit 1
     done

--- a/plugins/btrfs-subvolumes-mounted.sh
+++ b/plugins/btrfs-subvolumes-mounted.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 run_checks() {
-    MOUNTS=`grep "btrfs.*subvol=" /etc/fstab | awk '{print $2}'`
+    MOUNTS=$(grep "btrfs.*subvol=" /etc/fstab | awk '!/^[[:space:]]*#/{print $2}')
     for i in ${MOUNTS}; do
         path=$(systemd-escape -p "$(echo -e ${i})")
         systemctl is-failed -q "${path}.mount"


### PR DESCRIPTION
If btrfs-subvolume is mounted inside a hidden folder then the check "systemctl is-failed {path/containing/a/.dot/mountpoint}" will fail and return fault code 4 (program or service status is unknown).

The command "systemctl -t mount" will only contain the characters \x2e for some subvolumes, for example .snapshots will be \x2esnapshots.mount

However, here is one example from /etc/fstab that will not output \x2e instead of a dot: 
UUID=e3aca71c-68c0-4f38-ace9-24cfec405e6a \
  /home/user1/.local/share/containers btrfs subvol=containers 0 0

This will instead be printed in "systemctl -t mount" as: 
home-user1-.local-share-containers.mount

This patch will only replace the dot if it is the first character e.g .snapshots, but will not replace the dot in
/home/user1/.local/share/containers.

I do not know if there are other scenarios where "systemctl -t mount" will output \x2e instead of a dot,
I have only seen it for .snapshots (folders that starts with a "." ).

This issue has not been seen until a recent update of systemctl. On my previous snapshot "systemctl is-failed {/path/not/found.mount}" returned 1, but after the update of systemctl it will return 4 in case the mount-point does not exist.