### PR TITLE
Fix plugins/btrfs-subvolumes-mounted.sh for / (boo#1215368)

### DIFF
--- a/plugins/btrfs-subvolumes-mounted.sh
+++ b/plugins/btrfs-subvolumes-mounted.sh
@@ -4,7 +4,7 @@ run_checks() {
     MOUNTS=$(findmnt --types btrfs --options subvol --fstab --output target --raw --noheadings)
     for i in ${MOUNTS}; do
         path=$(systemd-escape -p -- "$(echo -e ${i})")
-        systemctl is-failed -q "${path}.mount"
+        systemctl is-failed -q -- "${path}.mount"
         test $? -ne 1 && exit 1
     done
 }


### PR DESCRIPTION
If / has a subvol= option, this plugin ended up calling systemctl is-failed -.mount which lead to an "invalid option" error. Add -- to make it clear that this is a unit name.