### PR TITLE
Add rpm db consistency plugin

### DIFF
--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -6,6 +6,6 @@ plugindir = ${libexecdir}/health-checker
 
 plugin_SCRIPTS = health-check-tester.sh etcd.sh etc-overlayfs.sh \
 	rebootmgr.sh btrfs-subvolumes-mounted.sh crio.sh kubelet.sh \
-	tmp.sh logind.sh
+	tmp.sh logind.sh rpmdb-consistency.sh
 
 EXTRA_DIST = template.sh ${SCRIPTS}

--- a/plugins/rpmdb-consistency.sh
+++ b/plugins/rpmdb-consistency.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+run_checks() {
+	zypper --no-refresh --quiet verify --dry-run
+	test $? -ne 0 && exit 1
+}
+
+case "$1" in
+    check)
+	run_checks
+	;;
+    *)
+	echo "Usage: $0 {check|stop}"
+	exit 1
+	;;
+esac
+
+exit 0


### PR DESCRIPTION
Ensure RPM database is always consistent (all dependencies are fulfilled) and revert to previous snapshot if not.