### PR TITLE
Improve rpmdb consistency check

### DIFF
--- a/plugins/rpmdb-consistency.sh
+++ b/plugins/rpmdb-consistency.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 run_checks() {
-	zypper --no-refresh --quiet verify --dry-run
+	# check rpm DB itself
+	rpm -D "%_rpmlock_path /run/rpmdb"  --verifydb
+	test $? -ne 0 && exit 1
+	# only rely on local/system repository for check
+	zypper --no-refresh --no-remote --non-interactive --quiet verify --dry-run
 	test $? -ne 0 && exit 1
 }
 

--- a/plugins/rpmdb-consistency.sh
+++ b/plugins/rpmdb-consistency.sh
@@ -3,9 +3,6 @@
 run_checks() {
 	# check rpm DB itself (need to override lock path, the default one is read-only)
 	rpm -D "%_rpmlock_path /run/rpmdb" --verifydb || exit 1
-	# only rely on local/system repository for check
-	zypper --no-refresh --no-remote --non-interactive --quiet verify --dry-run
-	test $? -ne 0 && exit 1
 }
 
 case "$1" in

--- a/plugins/rpmdb-consistency.sh
+++ b/plugins/rpmdb-consistency.sh
@@ -2,7 +2,7 @@
 
 run_checks() {
 	# check rpm DB itself
-	rpm -D "%_rpmlock_path /run/rpmdb"  --verifydb
+	rpm -D "%_rpmlock_path /run/rpmdb" --verifydb
 	test $? -ne 0 && exit 1
 	# only rely on local/system repository for check
 	zypper --no-refresh --no-remote --non-interactive --quiet verify --dry-run

--- a/plugins/rpmdb-consistency.sh
+++ b/plugins/rpmdb-consistency.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 run_checks() {
-	# check rpm DB itself
-	rpm -D "%_rpmlock_path /run/rpmdb" --verifydb
-	test $? -ne 0 && exit 1
+	# check rpm DB itself (need to override lock path, the default one is read-only)
+	rpm -D "%_rpmlock_path /run/rpmdb" --verifydb || exit 1
 	# only rely on local/system repository for check
 	zypper --no-refresh --no-remote --non-interactive --quiet verify --dry-run
 	test $? -ne 0 && exit 1


### PR DESCRIPTION
Check rpmdb is fine

Restrict zypper to local repository, it catches system db inconsistencies.