### PR TITLE
Fix typos: replace `health-checker.state` occurances with `health-check.state`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ responsible to check a special service or condition. For this, the plugin is
 called with the option *check*. If this fails, the plugin will exit with the
 return value `1`, else `0`.
 If everyting was fine, the script will create a
-`/var/lib/misc/health-checker.state` file with the number of the current,
+`/var/lib/misc/health-check.state` file with the number of the current,
 working btrfs subvolume with the root filesystem.
 If a plugin reports an error condition, the `health-checker` script will take
 following actions:

--- a/grub/05_health_check
+++ b/grub/05_health_check
@@ -18,8 +18,8 @@ if [ -z "\${chosen}" -a -z "\${boot_once}" ]; then
     btrfs-mount-subvol (\${root}) /var /@/var
     btrfs-mount-subvol (\${root}) /var/lib/misc /@/var/lib/misc
 
-    if [ -e /var/lib/misc/health-checker.state ]; then
-      source /var/lib/misc/health-checker.state
+    if [ -e /var/lib/misc/health-check.state ]; then
+      source /var/lib/misc/health-check.state
       if [ -n \${LAST_WORKING_SNAPSHOT} ]; then
         LAST_WORKING_SNAPSHOTS=\${LAST_WORKING_SNAPSHOT}
       fi
@@ -29,7 +29,7 @@ if [ -z "\${chosen}" -a -z "\${boot_once}" ]; then
     # health-checker versions):
     # Due to boo#1048088 btrfs-list-subvols currently doesn't give a list of
     # subvolumes, so it's not possible to map
-    # /var/lib/misc/health-checker.state to a snapshot directory; use
+    # /var/lib/misc/health-check.state to a snapshot directory; use
     # transactional-update state file as a workaround.
     if [ -z \${LAST_WORKING_SNAPSHOTS} -a -e /var/lib/misc/transactional-update.state ]; then
       source /var/lib/misc/transactional-update.state


### PR DESCRIPTION
The readme as well as the `grub/05_health_check` script specify the path `/var/lib/misc/health-checker.state`.
The actual `STATE_FILE` is supposed to be `/var/lib/misc/health-check.state` (`check.state`, not `checker.state`), as defined in `/sbin/health-checker.in`.

Using the `health-check.state` variant is more consistent with the path of  `REBOOTED_STATE` (`/var/lib/misc/health-check.rebooted`).

Fixes #23 