### PR TITLE
Set RemainAfterExit=yes

### DIFF
--- a/systemd/health-checker.service
+++ b/systemd/health-checker.service
@@ -11,6 +11,7 @@ Wants=local-fs.target
 [Service]
 Type=oneshot
 ExecStart=/usr/sbin/health-checker
+RemainAfterExit=yes
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Otherwise it gets started on each start of a dependent target.