### PR TITLE
Add plugin for k3s server and agent

### DIFF
--- a/plugins/k3s-agent.sh
+++ b/plugins/k3s-agent.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+run_checks() {
+    # ignore if k3s-agent is not enabled.
+    systemctl is-enabled -q k3s-agent
+    test $? -ne 0 && return
+
+    systemctl is-failed -q k3s-agent
+    test $? -ne 1 && exit 1
+
+    systemctl is-active -q k3s-agent
+    test $? -ne 0 && exit 1
+}
+
+stop_services() {
+    systemctl stop k3s-agent
+}
+
+case "$1" in
+    check)
+        run_checks
+        ;;
+    stop)
+        stop_services
+        ;;
+    *)
+        echo "Usage: $0 {check|stop}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/plugins/k3s.sh
+++ b/plugins/k3s.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+run_checks() {
+    # ignore if k3s is not enabled.
+    systemctl is-enabled -q k3s
+    test $? -ne 0 && return
+
+    systemctl is-failed -q k3s
+    test $? -ne 1 && exit 1
+
+    kubectl cluster-info
+    test $? -ne 0 && exit 1
+}
+
+stop_services() {
+    systemctl stop k3s
+}
+
+case "$1" in
+    check)
+        run_checks
+        ;;
+    stop)
+        stop_services
+        ;;
+    *)
+        echo "Usage: $0 {check|stop}"
+        exit 1
+        ;;
+esac
+
+exit 0

--- a/systemd/health-checker.service
+++ b/systemd/health-checker.service
@@ -6,6 +6,8 @@ After=etcd.service
 After=kubelet.service
 After=rebootmgr.service
 After=systemd-logind.service
+After=k3s.service
+After=k3s-agent.service
 Wants=local-fs.target
 
 [Service]


### PR DESCRIPTION
For K3s servers the plugin checks `k3s.service` and cluster availability using `kubectl`. For K3s agents `k3s-agent.service` is being checked to be active.