### PR TITLE
Use systemd Boot Assessment

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,45 @@ Check the state of a openSUSE MicroOS system after a reboot.
 `health-checker` will be called by a systemd service during the boot
 process.
 
-The `health-checker` script will call several plugins. Every plugin is
-responsible to check a special service or condition. All services, which
-should be checked by the plugin, needs to be listed in the 'After' section.
-To run the check the plugin is called with the option *check*. If this fails,
-the plugin will exit with the return value `1`, else `0`.
-If everyting was fine, the script will create a
+The `health-checker` script will call several plugins; each plugin is
+responsible to check a special service or condition. To run the check, the
+plugin is called with the option *check* (e.g.
+`/usr/libexec/health-checker/tmp.sh check`). If this fails, the plugin will
+exit with the return value `1`, else `0`. The `health-checker` script will call
+all plugins inside `/usr/libexec/health-checker` and
+`/usr/local/libexec/health-checker` directories; the former directory includes
+plugins installed by system packages (and therefore coming through an RPM), the
+latter includes plugins installed manually by the system admin. All services,
+which should be checked by the plugins, needs to be listed in the 'After'
+section, so that they are started before `health-checker`.
+
+Its behavior depends if the system is using systemd-boot, grub2-bls or any
+other bootloader following the Boot Loader Specification (BLS) or legacy.
+
+### systemd-boot and grub2-bls
+
+On systemd-boot and grub2-bls, when the BLS is followed, `health-checker`
+assess the status of the system at the boot and act accordingly. It uses the
+[Automatic Boot Assessment](https://systemd.io/AUTOMATIC_BOOT_ASSESSMENT/)
+provided by systemd to check every new snapshot, to reboot a predetermined
+amount of times, and then it lets the user access an emergency shell when
+everything else fails.
+
+Every new snapshot has a separate boot entry with a boot counter (according to
+`/etc/kernel/tries`, which health-checker sets to 3 by default); when that
+snapshot is booted for the first time, the bootloader will decrease the amount
+of tries left. Then if health-checker succeed, systemd will call
+`systemd-bless-boot`, which will mark the new snapshot as working. If instead
+`health-checker` fails, the system will reboot into the next available
+snapshot, performing a rollback at boot. The bootloader will order the snapshot
+depending if they are new/working, leaving all the non working snapshots last
+(so with a non 0 boots available left). If an entry that was working previously
+is now broken, `health-checker` will try rebooting once before starting an
+emergency shell.
+
+### Legacy grub
+
+If everything was fine, the script will create a
 `/var/lib/misc/health-check.state` file with the number of the current,
 working btrfs subvolume with the root filesystem.
 If a plugin reports an error condition, the `health-checker` script will take

--- a/man/health-checker.8.xml.in
+++ b/man/health-checker.8.xml.in
@@ -62,11 +62,27 @@
   <refsect1 id='description'><title>DESCRIPTION</title>
   <para><emphasis remap='B'>health-checker</emphasis>
   checks if the system is coming up correctly during boot up.
-  In case of an error, the remediation action depends on what happened before.
-  If this is the first boot after a transactional update, an automatic rollback
-  to the last known working snapshot is executed. If the snapshot was already
-  rebooted successfully before, a reboot is tried. If this does not help,
-  some sevices are shutdown and an admin has to repair the system.
+  The behavior depends if the system is using systemd-boot/grub2-bls
+  or legacy grub2.</para>
+  <para>With systemd-boot/grub2-bls: the bootloader picks the first available entry
+  and health-checker checks that the system has booted successfully. When
+  any plugin fails, then health-checker will behave depending on the entry
+  booted: if it is a snapshot that has previously been booted successfully
+  then health-checker will try rebooting the system once more, and it will
+  open an emergency shell if the system still fails to boot.
+  If this is the first boot of a new snapshot, then the system will reboot
+  a number of timed configured in <filename>/etc/kernel/tries</filename>,
+  checking the status each time. If the system stills fails to boot, then
+  health-checker marks the current entry as not working and reboot. The
+  bootloader will pick the next available boot entry.
+  It is possible to disable health-checker automated rebooting by adding
+  <command>"health-checker-reboot=disabled"</command> to the kernel cmdline.</para>
+  <para>In case of an error and legacy grub2 is used, the remediation action depends
+  on what happened before. If this is the first boot after a transactional
+  update, an automatic rollback to the last known working snapshot is
+  executed. If the snapshot was already rebooted successfully before, a
+  reboot is tried. If this does not help, some services are shutdown and an
+  admin has to repair the system.
   </para>
   <para>
     If the boot was successful, the current snapshot is marked as known to be

--- a/plugins/health-check-tester.sh
+++ b/plugins/health-check-tester.sh
@@ -6,6 +6,11 @@
 
 run_checks() {
 
+   # Check if the system is running legacy grub as the check file
+   # is only used there
+   if [ -d /boot/efi/loader/entries ]; then
+       return 0
+   fi
 # Simple check: if this is the very first boot, succeed.
 # If not, fail.
    if [ -f /var/lib/misc/health-check.state ]; then

--- a/sbin/health-checker.in
+++ b/sbin/health-checker.in
@@ -21,11 +21,30 @@ BTRFS_ID_DEFAULT=0
 SNAPSHOT_DEFAULT=""
 BTRFS_ID_CURRENT=0
 
+is_bls=0
+if [ -d /boot/efi/loader/entries ]; then
+    is_bls=1
+fi
+
 set_btrfs_id()
 {
     BTRFS_ID_DEFAULT=`btrfs subvolume get-default / | awk '{print $2}'`
     SNAPSHOT_DEFAULT="`btrfs subvolume get-default / | cut -d ' ' -f 9-`"
     BTRFS_ID_CURRENT=`findmnt --output OPTIONS --noheadings / | sed -e 's|.*subvolid=\([0-9]\+\).*|\1|g'`
+}
+
+get_snapshot()
+{
+    sed -e 's|.*@/\.snapshots/\([0-9]\+\)/snapshot.*|\1|g'
+}
+
+set_snapshot_id()
+{
+    SNAPSHOT_DEFAULT="$(btrfs subvolume get-default / | get_snapshot)"
+    SNAPSHOT_CURRENT="$(findmnt --output OPTIONS --noheadings --first-only --direction backward /usr | get_snapshot)"
+    if [ -z "${SNAPSHOT_CURRENT}" ]; then
+        SNAPSHOT_CURRENT="$(findmnt --output OPTIONS --noheadings --first-only --direction backward / | get_snapshot)"
+    fi
 }
 
 create_log()
@@ -103,7 +122,24 @@ stop_services()
     done
 }
 
-error_decission()
+# We want to enter an emergency shell just once every boot, otherwise
+# systemd restarts health-checker every time the user continues from
+# the emergency shell. This causes a loop with no way to exit the emergency shell
+# other than fixing the issue
+start_emergency_shell() {
+    if [ ! -f /run/health-checker/.emergency-shell-started ]; then
+        create_log user.emerg "Machine didn't come up correctly, starting emergency shell"
+        telem_send_record 1
+        mkdir /run/health-checker
+        touch /run/health-checker/.emergency-shell-started
+        stop_services
+        systemctl start emergency.target
+    else
+        exit 1
+    fi
+}
+
+error_decision_legacy()
 {
     if [ ! -f ${STATE_FILE} ]; then
 	# No state file, no successful boot
@@ -133,15 +169,105 @@ error_decission()
       telem_send_record 1
       systemctl reboot
   else
-      create_log user.emerg "Machine didn't come up correctly, starting emergency shell"
-      stop_services
-      systemctl start emergency.target
+      start_emergency_shell
   fi
 }
 
-# Clear GRUB flag (used to determine if system was able to boot at all)
-echo "Clearing GRUB flag"
-grub2-editenv - set health_checker_flag=0
+systemd-bless-boot() {
+    if [ -x /usr/lib/systemd/systemd-bless-boot ]; then
+        /usr/lib/systemd/systemd-bless-boot "$@"
+    fi
+}
+
+get_current_entry_bls() {
+    bootctl list --json=short | jq -r ".[] | select(.isSelected) | .id"
+}
+
+error_decision_bls() {
+    local status should_reboot current_entry
+    # systemd-bless-boot returns:
+    #   clean: boot counting is not in effect
+    #   good:  this entry booted fine. Since we are calling this at boot,
+    #          it shouldn't be possible to return "good"
+    #   dirty:   this entry has no more tries available
+    #   indeterminate: when an entry is neither good or bad, i.e.
+    #                  we are still trying to boot 3 times
+    status=$(systemd-bless-boot status)
+    # The bootloader fills the EFI variables with the info we need
+
+    # Get the booted entry
+    current_entry=$(get_current_entry_bls)
+    should_reboot=0
+    # Do not reboot by default if the entry has been chosen manually or the reboot has
+    # been disabled in the kernel cmdline
+    # selected_entry contains the boot count, remove it before comparing it to the default entry
+    if ! grep -qw "health-checker-reboot=disabled" /proc/cmdline; then
+        should_reboot=1
+    fi
+    set_snapshot_id
+    # the entry is the default one
+    case "$status" in
+        # boot counting is still in effect, let systemd-boot do the rest
+        "indeterminate")
+            if [ "$should_reboot" -eq 1 ]; then
+                create_log user.alert "Machine didn't come up correctly, trying the same snapshot"
+                # We want to reboot into the current snapshot
+                bootctl set-oneshot "$current_entry"
+                systemctl reboot
+            fi
+            start_emergency_shell $should_reboot
+            ;;
+        "dirty")
+            if [ "$should_reboot" -eq 1 ]; then
+                create_log user.alert "Machine didn't come up correctly, rebooting a different snapshot"
+                echo "NEW_SNAPSHOT_FAILED=1" > $STATE_FILE
+                if [ "$SNAPSHOT_DEFAULT" == "$SNAPSHOT_CURRENT" ]; then
+                    # If the default entry has been marked as not dirty, tell
+                    # the bootloader to pick the first new / working snapshot
+                    bootctl set-default ""
+                fi
+                systemctl reboot
+            fi
+            start_emergency_shell $should_reboot
+            ;;
+        "clean"|"good")
+            [ -f $STATE_FILE ] && . $STATE_FILE
+            # We want to reboot into the current snapshot to try one more time if it works
+            if [ "$REBOOTING_GOOD_SNAPSHOT" != "$SNAPSHOT_CURRENT" ] && [ "$should_reboot" -eq 1 ]; then
+                create_log user.alert "Machine didn't come up correctly, trying same snapshot"
+                bootctl set-oneshot "$current_entry"
+                sed -i '/REBOOTING_GOOD_SNAPSHOT/d' $STATE_FILE
+                echo "REBOOTING_GOOD_SNAPSHOT=$SNAPSHOT_CURRENT" >> $STATE_FILE
+                systemctl reboot
+            fi
+            start_emergency_shell
+            ;;
+        "bad")
+            start_emergency_shell
+            ;;
+        *)
+            create_log user.alert "Machine didn't come up correctly, found unexpected verb in systemd-bless-boot"
+            reboot_or_emergency_shell $should_reboot
+            ;;
+        # good should never appear here because systemd-bless-boot.service that
+        # marks an entry as "good" is called after boot.entry (and health-checker as well)
+        # All the next reboots for the same entry will have a "clean" state
+    esac
+}
+
+error_decision() {
+    if [ "$is_bls" == "1" ]; then
+        error_decision_bls
+    else
+        error_decision_legacy
+    fi
+}
+
+if [ "$is_bls" != "1" ]; then
+    # Clear GRUB flag (used to determine if system was able to boot at all)
+    echo "Clearing GRUB flag"
+    grub2-editenv - set health_checker_flag=0
+fi
 
 echo "Starting health check"
 FAILED=0;
@@ -157,20 +283,34 @@ done
 
 if [ ${FAILED} -ne 0 ]; then
     echo "Health check failed!"
-    error_decission
+    error_decision
     telem_send_record 0
     exit 1
 else
     echo "Health check passed"
-    # Save good working state and remove old rebooted state file
-    save_working_snapshot
-    if [ -f ${REBOOTED_STATE} ]; then
-        create_log user.info "Health check passed after reboot"
-        rm -rf ${REBOOTED_STATE}
+    if [ "$is_bls" != "1" ]; then
+        # Save good working state and remove old rebooted state file
+        save_working_snapshot
+        if [ -f ${REBOOTED_STATE} ]; then
+            create_log user.info "Health check passed after reboot"
+            rm -rf ${REBOOTED_STATE}
+        fi
+    else
+        NEW_SNAPSHOT_FAILED=0
+        REBOOTING_GOOD_SNAPSHOT=""
+        [ -f $STATE_FILE ] && . $STATE_FILE
+        set_snapshot_id
+        # If the new snapshot failed, update the default to the current one
+        if [ "$NEW_SNAPSHOT_FAILED" -eq 1 ] && [ "$SNAPSHOT_CURRENT" != "$SNAPSHOT_DEFAULT" ]; then
+            if ! sdbootutil set-default-snapshot "$SNAPSHOT_CURRENT" ; then
+               create_log user.crit "Cannot set current snapshot as default boot entry using sdbootutil"
+            fi
+        fi
+        [ -f $STATE_FILE ] && rm $STATE_FILE
     fi
 fi
 
-
+echo "Health check passed"
 if [ -z "${TELEM_PAYLOAD}" ]; then
     TELEM_PAYLOAD="Health check passed"
 fi

--- a/systemd/health-checker.service
+++ b/systemd/health-checker.service
@@ -14,4 +14,5 @@ ExecStart=/usr/sbin/health-checker
 RemainAfterExit=yes
 
 [Install]
+RequiredBy=boot-complete.target
 WantedBy=default.target


### PR DESCRIPTION
[Automatic Boot Assessment](https://systemd.io/AUTOMATIC_BOOT_ASSESSMENT/) allows systemd-boot and systemd to mark boot entries as either good or bad, depending on if they can boot successfully or not.

This PR changes health-checker into a service that is part of the automatic boot assessment, by using the special target `boot-complete.target`. When systemd-boot and `/etc/kernel/tries` is greater than 0, the current boot entry get renamed to start the counting.

If health-checker tests pass without errors, then the boot entry is marked as good by systemd-bless-boot. If there is any error, then health-checker decides if there should be a reboot, or it should start an emergency shell. If the current entry is the default one and the entry has still some tries left (i.e. it has not been marked as `bad`), then reboot. If the current entry is the default one and there are no tries left, then start an emergency shell. The default entry will be picked among the one that are known to work or haven't been tested yet, so the emergency shell is only started when all entries have been tried (this could lead to many reboots). If the user choose an entry instead of letting systemd-boot pick the default one, then health-checker will not reboot by default (this can be enforced with the argument below).

I have also added two kernel cmdline arguments to fix #8 :
- `health-checker-reboot`:
  - `force`: always reboot when health-checker fails and the loaded boot entry is not the default one
  -  `disable`: health-checker never reboots
- `health-checker=disabled`: skill all tests and mark health-checker as successful. This breaks systemd Automatic Boot Counting but helps with debugging or some edge cases.

## Requirements
- `/etc/kernel/tries` to have a number greater than 0. Currently, I am shipping this file in the health-checker package.

## Current blockers
- systemd-bless-boot cannot rename the boot entries, due to selinux enforcing policy. Bug tracked [here](https://bugzilla.suse.com/show_bug.cgi?id=1232527).